### PR TITLE
Change status overlay from SplashText to transparent GUI.

### DIFF
--- a/Sublimation.ahk
+++ b/Sublimation.ahk
@@ -37,7 +37,7 @@ If (!CharSecondaryId)
 
 ; initial load
 CharActive := CharPrimary
-Sublimation()  ; Black magic!! ✨🧙✨
+Sublimation(CharActive)  
 
 
 ;------------------------------------------------------------------------------
@@ -45,20 +45,20 @@ Sublimation()  ; Black magic!! ✨🧙✨
 ;------------------------------------------------------------------------------
 
 StatusFont = "Arial"  ; list of available fonts https://www.autohotkey.com/docs/misc/FontsStandard.htm
-StatusFontSize = "16"
+StatusFontSize = "14"
 StatusErrColor := "FF0000"  ; https://www.autohotkey.com/docs/commands/Progress.htm#colors 
 StatusOkColor := "009900"   ; or use the Hex values from https://www.google.com/search?q=rgb+colour+picker 
 GuiBgColor := "000000"  ; Can be any RGB color (it will be made transparent below).
 
 Gui +LastFound +AlwaysOnTop -Caption +ToolWindow  ; +ToolWindow avoids a taskbar button and an alt-tab menu item.
 Gui, Color, %GuiBgColor%
-Gui, Font, s%StatusFontSize% c%StatusOkColor%, %StatusFont%
-Gui, Add, Text, vStatusText c%StatusOkColor%, XXXXXXXX YY  ; XX & YY serve to auto-size the window.
+Gui, Font, s%StatusFontSize% c%StatusOkColor% bold, %StatusFont%
+Gui, Add, Text, vStatusText c%StatusOkColor%, XXXXXX YYYYYY  ; XX & YY serve to auto-size the window.
 ; Make all pixels of this color transparent and make the text itself translucent (150):
-WinSet, TransColor, %GuiBgColor% 255  ; valid values 0-255 - 255 is not transparent
+WinSet, TransColor, %GuiBgColor% 255
 SetTimer, UpdateOSD, 200
 Gosub, UpdateOSD  ; Make the first update immediate rather than waiting for the timer.
-Gui, Show, y5, NoActivate  ; NoActivate avoids deactivating the currently active window.
+Gui, Show, y20, NoActivate  ; NoActivate avoids deactivating the currently active window.
 Return
 
 UpdateOSD:
@@ -93,7 +93,7 @@ return
 ; Toggle Characters
 #Tab::
   CharActive := CharActive = CharPrimary ? CharSecondary : CharPrimary
-  Sublimation()
+  Sublimation(CharActive)
 return
 
 
@@ -108,11 +108,13 @@ Boolean(bool)
 }
 
 ; Switch active Windows
-Sublimation()
+; https://en.wikipedia.org/wiki/Sublimation_(phase_transition)
+; Black magic!! ✨🧙✨
+Sublimation(char)
 {
-  ; https://en.wikipedia.org/wiki/Sublimation_(phase_transition)
-  WinShow, %CharActive%
-  WinActivate, %CharActive%
+  WinShow, %char%
+  WinActivate, %char%
+  Return
 }
 
 ; Update GUI status text
@@ -120,7 +122,7 @@ UpdateStatus(StatusColor, StatusMessage)
 {
   Gui, Font, s%StatusFontSize% c%StatusColor%, %StatusFont%
   GuiControl, Font, Static1  ; Static1 is the AHK ClassNN - changing this will break the OSD!!
-  GuiControl, Move, StatusText, XXXXXXXX YY
+  GuiControl, Move, StatusText, W1400
   GuiControl,, StatusText, %StatusMessage%`
 }
 

--- a/Sublimation.ahk
+++ b/Sublimation.ahk
@@ -19,7 +19,7 @@ CharActive := ""
 
 
 ;------------------------------------------------------------------------------
-; Globals
+; Init
 ;------------------------------------------------------------------------------
 CmdRouterSwitch := true
 Active := Boolean(CmdRouterSwitch)
@@ -35,43 +35,42 @@ If (!CharSecondaryId)
   MsgBox % "FFXI client instance for " . CharSecondary . " not found."
 }
 
-;------------------------------------------------------------------------------
-; Functions
-;------------------------------------------------------------------------------
-
-; convert boolean to string
-Boolean(bool)
-{
-  return bool = true ? "True" : "False"
-}
-
-; refresh the splash window
-UpdateSplashStatus(CmdRouterActive, ActiveCharacter)
-{
-  splashText := ""
-
-  If (CmdRouterActive = "True") {
-    splashText := Format("Command Router Active: {} || Character: {}", CmdRouterActive, ActiveCharacter)
-  }
-  If (CmdRouterActive = "False") {
-    splashText := Format("Command Router Active: {}", CmdRouterActive)
-  }
-
-  SplashTextOn, 400, 25, Cmd Router, %splashText%
-  WinMove, Cmd Router, , , 0,
-  WinSet, Transparent, 200, Cmd Router,
-}
-
-
-;------------------------------------------------------------------------------
-; Init
-;------------------------------------------------------------------------------
-
-; initial splash on load
+; initial load
 CharActive := CharPrimary
-UpdateSplashStatus(Active, CharActive)
-WinShow, %CharActive%
-WinActivate, %CharActive%
+Sublimation()  ; Black magic!! ✨🧙✨
+
+
+;------------------------------------------------------------------------------
+; Onscreen Display
+;------------------------------------------------------------------------------
+
+StatusFont = "Arial"  ; list of available fonts https://www.autohotkey.com/docs/misc/FontsStandard.htm
+StatusFontSize = "16"
+StatusErrColor := "FF0000"  ; https://www.autohotkey.com/docs/commands/Progress.htm#colors 
+StatusOkColor := "009900"   ; or use the Hex values from https://www.google.com/search?q=rgb+colour+picker 
+GuiBgColor := "000000"  ; Can be any RGB color (it will be made transparent below).
+
+Gui +LastFound +AlwaysOnTop -Caption +ToolWindow  ; +ToolWindow avoids a taskbar button and an alt-tab menu item.
+Gui, Color, %GuiBgColor%
+Gui, Font, s%StatusFontSize% c%StatusOkColor%, %StatusFont%
+Gui, Add, Text, vStatusText c%StatusOkColor%, XXXXXXXX YY  ; XX & YY serve to auto-size the window.
+; Make all pixels of this color transparent and make the text itself translucent (150):
+WinSet, TransColor, %GuiBgColor% 255  ; valid values 0-255 - 255 is not transparent
+SetTimer, UpdateOSD, 200
+Gosub, UpdateOSD  ; Make the first update immediate rather than waiting for the timer.
+Gui, Show, y5, NoActivate  ; NoActivate avoids deactivating the currently active window.
+Return
+
+UpdateOSD:
+If (Active == "True") 
+{
+  UpdateStatus(StatusOkColor, CharActive)
+} 
+Else 
+{
+  UpdateStatus(StatusErrColor, "Sublimation ❌")
+}
+Return
 
 
 ;------------------------------------------------------------------------------
@@ -89,13 +88,39 @@ F12::
   Suspend
   CmdRouterSwitch := !CmdRouterSwitch
   Active := Boolean(CmdRouterSwitch)
-  UpdateSplashStatus(Active, CharActive)
 return
 
 ; Toggle Characters
 #Tab::
   CharActive := CharActive = CharPrimary ? CharSecondary : CharPrimary
-  UpdateSplashStatus(Active, CharActive)
+  Sublimation()
+return
+
+
+;------------------------------------------------------------------------------
+; Functions
+;------------------------------------------------------------------------------
+
+; Convert boolean to string
+Boolean(bool)
+{
+  return bool = true ? "True" : "False"
+}
+
+; Switch active Windows
+Sublimation()
+{
+  ; https://en.wikipedia.org/wiki/Sublimation_(phase_transition)
   WinShow, %CharActive%
   WinActivate, %CharActive%
-return
+}
+
+; Update GUI status text
+UpdateStatus(StatusColor, StatusMessage)
+{
+  Gui, Font, s%StatusFontSize% c%StatusColor%, %StatusFont%
+  GuiControl, Font, Static1  ; Static1 is the AHK ClassNN - changing this will break the OSD!!
+  GuiControl, Move, StatusText, XXXXXXXX YY
+  GuiControl,, StatusText, %StatusMessage%`
+}
+


### PR DESCRIPTION
The original status overlay was quite large and obtrusive. The GUI overlay only displays the status text and the GUI box itself is transparent.

The text has been colour coded depending on whether the script is running or suspended.